### PR TITLE
Ajout du client FTP dans buildTree

### DIFF
--- a/lib/storage/ftp.js
+++ b/lib/storage/ftp.js
@@ -22,7 +22,7 @@ export async function buildTree(path, client) {
     }
 
     if (node.isDirectory) {
-      node.children = await buildTree(fullPath)
+      node.children = await buildTree(fullPath, client)
     }
 
     tree.push(node)


### PR DESCRIPTION
Cette PR corrige l'erreur liée à l'absence du client FTP lors de l'appel de la fonction `buildTree`