### PR TITLE
Ajoute une propriété pour identifier une erreur à la lecture des fichiers scannés

### DIFF
--- a/lib/scan.js
+++ b/lib/scan.js
@@ -60,6 +60,7 @@ export async function scan(storage) {
         progress.analyzedDataFiles++
       } catch (error) {
         console.log(error)
+        progress.brokenDataSampleError ||= error.message
         progress.brokenDataFiles++
         await updateTreeItemAnalyzeError(dataItem._id, error.message)
       }


### PR DESCRIPTION
Cette PR ajoute un champ `brokenDataSampleError` afin d'aider l'utilisateur à identifier un problème avec ses fichiers scannés.

